### PR TITLE
Add perform_caching instructions in Usage readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Or install it yourself as:
 
 ## Usage
 
+Set `config.action_controller.perform_caching = true` in `config/environments/test.rb`
+
 Add `caching: true` as an option around a controller example group and use
 a proc or lambda around the action for matching:
 


### PR DESCRIPTION
I couldn't get this working until I took this step, and had originally assumed this step wasn't necessary due to the ":caching => true" option for example groups, but that was not the case.
