### PR TITLE
Update matchers to be compatible with RSpec 3

### DIFF
--- a/lib/rspec-rails-caching/matchers/base.rb
+++ b/lib/rspec-rails-caching/matchers/base.rb
@@ -13,16 +13,16 @@ module RSpecRailsCaching
           "#{cache_or_expire} #{expected.inspect}"
         end
 
-        failure_message_for_should_not do |actual|
+        failure_message_when_negated do |actual|
           "Expected #{controller.class} not to #{cache_or_expire} #{expected.inspect} but got #{cache_results.inspect}"
         end
 
-        failure_message_for_should do |actual|
+        failure_message do |actual|
           "Expected #{controller.class} to #{cache_or_expire} #{expected.inspect} but got #{cache_results.inspect}"
         end
 
-        def controller
-          matcher_execution_context.controller
+        def supports_block_expectations?
+          true
         end
 
         def cache_store
@@ -37,7 +37,7 @@ module RSpecRailsCaching
           fail NoMethodError, "Abstract method 'cache_or_expire' to be defined in matcher"
         end
 
-        instance_eval &block
+        module_eval &block
 
       end
     end

--- a/rspec-rails-caching.gemspec
+++ b/rspec-rails-caching.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |gem|
   gem.description = %q{RSpec helper for testing page and action caching in Rails}
 
   gem.add_dependency "rails", ">=3.0.0"
-  gem.add_dependency "rspec", ">=2.8.0"
-  gem.add_dependency "rspec-rails", ">=2.10.0"
+  gem.add_dependency "rspec", ">=3.0.0"
+  gem.add_dependency "rspec-rails", ">=3.0.0"
 
   gem.files         = `git ls-files`.split($\)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Thanks for this gem!

This updates the matchers to work with RSpec 3 and not issue deprecations.

I updated the gemspec to rely on RSpec 3 or higher, though with some more work I suppose the changes could be adapted to support both RSpec 2 and 3, but I'm not sure if there's value in that.

The test suite passes as well as the test suite for my application using these matchers.
