### PR TITLE
Add compatibility with actionpack-page_caching v1.1.0

### DIFF
--- a/lib/rspec-rails-caching.rb
+++ b/lib/rspec-rails-caching.rb
@@ -13,8 +13,15 @@ module RSpecRailsCaching
         Object.const_set :RAILS_CACHE, TestStore.new(do_read_cache: true)
       end
       ActionController::Base.cache_store = RAILS_CACHE
-      ActionController::Base.class_eval do
-        extend Extensions::ActionController::ClassMethods
+
+      if defined?(ActionController::Caching::Pages::PageCache)
+        ActionController::Caching::Pages::PageCache.class_eval do
+          prepend Extensions::ActionController::Caching::Pages::PageCache
+        end
+      else
+        ActionController::Base.class_eval do
+          extend Extensions::ActionController::ClassMethods
+        end
       end
 
       RSpec::Rails::ControllerExampleGroup.class_eval do

--- a/lib/rspec-rails-caching/extensions/action_controller.rb
+++ b/lib/rspec-rails-caching/extensions/action_controller.rb
@@ -16,5 +16,24 @@ module RSpecRailsCaching::Extensions
       end
     end
 
+    module Caching
+      module Pages
+        module PageCache
+          def expire(path)
+            instrument :expire_page, path do
+              ::ActionController::Base.cache_store.cached_pages.delete path
+              ::ActionController::Base.cache_store.expired_pages << path
+            end
+          end
+
+          def cache(content, path, *)
+            instrument :write_page, path do
+              ::ActionController::Base.cache_store.cached_pages << path
+            end
+          end
+        end
+      end
+    end
+
   end
 end

--- a/rspec-rails-caching.gemspec
+++ b/rspec-rails-caching.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |gem|
   gem.summary     = %q{RSpec Rails Caching}
   gem.description = %q{RSpec helper for testing page and action caching in Rails}
 
+  gem.required_ruby_version = Gem::Requirement.new(">= 2.0.0")
+
   gem.add_dependency "rails", ">=3.0.0"
   gem.add_dependency "rspec", ">=2.8.0"
   gem.add_dependency "rspec-rails", ">=2.10.0"


### PR DESCRIPTION
actionpack-page_caching v1.1.0 rewrote the internals of performing the page caching to happen inside a different class (https://github.com/rails/actionpack-page_caching/commit/43dd478916e8e22e2412150145c8a2990369db59), so this updates our fake-caching to reflect the changes.

Should maintain compatibility with actionpack-page_caching <= 1.1.0. I tested locally with Rails 3.2 (page caching built in) and with newer rails with actionpack-page_caching 1.0.2 and 1.1.0 (before and after the problematic change).

Requires ruby 2.0 due to the use of Module#prepend to add our stubs.